### PR TITLE
Moved Chat Breaking to Medium for Large Phones

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -203,6 +203,11 @@ Authors:
     #sidebar {
         width: 200px;
     }
+    
+    #chat .msg {
+        display: block;
+        padding: 2px 10px;
+    }
 }
 
 .channel-list-item,


### PR DESCRIPTION
For phones larger than small (479): Pixel 7, chat messages lose precious real-estate, moved to <= medium (768)
- This is an upstream change, but this is the only theme I use.  
- iPad Mini resolution will display the same as <=  768