### PR TITLE
Move all Small breakpoints to Medium

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -203,11 +203,6 @@ Authors:
     #sidebar {
         width: 200px;
     }
-    
-    #chat .msg {
-        display: block;
-        padding: 2px 10px;
-    }
 }
 
 .channel-list-item,
@@ -401,7 +396,7 @@ code {
     visibility: visible;
 }
 
-@media (max-width: 479px) {
+@media (max-width: 768px) {
     #chat .previous-source .from,
     #chat .previous-source .time {
         visibility: visible;
@@ -454,4 +449,93 @@ code {
 /* Mentions popup */
 .mentions-popup .msg .content {
     background-color: var(--dark-bg-color);
+}
+
+
+/* Upstream Changes */
+
+@media (min-width: 768px) {
+	/* Fade out for long usernames */
+	#chat .from {
+		padding-left: 10px;
+		mask-image: linear-gradient(to left, transparent, black 10px);
+	}
+}
+
+@media (max-width: 768px) {
+	.container {
+		max-width: 100%;
+		margin: 0;
+	}
+
+	#sign-in .btn {
+		width: 100%;
+	}
+
+	.input {
+		margin-bottom: 2px;
+	}
+
+	#connect .connect-row {
+		flex-direction: column;
+	}
+
+	#connect .connect-row > .input,
+	#connect .connect-row > .input-wrap {
+		flex-grow: 1;
+	}
+
+	#help .help-version-title {
+		flex-direction: column;
+	}
+
+	#chat .messages {
+		display: block;
+		padding: 5px 0;
+	}
+
+	#chat .msg {
+		display: block;
+		padding: 2px 10px;
+	}
+
+	#chat .msg[data-type="condensed"] .msg {
+		padding: 2px 0;
+	}
+
+	#chat .time,
+	#chat .from,
+	#chat .content {
+		border: 0;
+		display: inline;
+		padding: 0;
+	}
+
+	#chat .from::after {
+		/* Add a space because mobile view changes to block display without paddings */
+		content: " ";
+		white-space: pre;
+	}
+
+	#chat .chat-view[data-type="channel"] .msg.highlight {
+		padding-left: 5px;
+	}
+
+	#chat .chat-view[data-type="channel"] .msg.highlight .time {
+		padding-left: 0;
+	}
+
+	#chat .condensed-summary .time,
+	#chat .condensed-summary .from {
+		display: none;
+	}
+
+	#help .help-item .subject {
+		display: inline-block;
+		padding-bottom: 4px;
+	}
+
+	#help .help-item .description {
+		display: block;
+	}
 }

--- a/mininapse.css
+++ b/mininapse.css
@@ -454,7 +454,7 @@ code {
 
 /* Upstream Changes */
 
-@media (min-width: 768px) {
+@media (min-width: 769px) {
 	/* Fade out for long usernames */
 	#chat .from {
 		padding-left: 10px;


### PR DESCRIPTION
Update all styles so that the minimum `max-width` is 768px.  This is a controversial change, so I'll keep it contained to this repo.  All these changes are upstream changes, but are included in my daily theme.
- Current gen phones such as Pixel 6a / Pixel 7 will behave the same as previous generation Pixel 5.
- All changes were done in sections for easy maintainability based on source.